### PR TITLE
✨ Feat/82 Q&A API 구현

### DIFF
--- a/src/main/java/com/example/umcmatchingcenter/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/umcmatchingcenter/apiPayload/code/status/ErrorStatus.java
@@ -60,6 +60,10 @@ public enum ErrorStatus implements BaseErrorCode {
     //학교 관련 에러
     UNIVERSITY_NOT_FOUND(BAD_REQUEST, "UNIVERSITY4001", "학교가 존재하지 않습니다."),
 
+    // Q&A 관련 에러
+    QUESTION_NOT_FOUNT(BAD_REQUEST, "QUESTION4001", "질문이 존재하지 않습니다."),
+    ANSWER_UNAUTHORIZED(BAD_REQUEST, "ANSWER4002", "질문에 대한 답변 권한이 없습니다."),
+
     // 예시,,,
     ARTICLE_NOT_FOUND(NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 

--- a/src/main/java/com/example/umcmatchingcenter/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/umcmatchingcenter/apiPayload/code/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_ALARM_LIST(BAD_REQUEST, "ALARM4002", "알림이 존재하지 않습니다."),
 
     // 프로젝트 관련 에러
+    PROJECT_NOT_EXIST(BAD_REQUEST, "PROJECT4001", "프로젝트가 존재하지 않습니다."),
     PROJECT_NOT_COMPLETE(BAD_REQUEST, "PROJECT4002", "완료된 프로젝트가 아닙니다."),
     PROJECT_NOT_PROCEEDING(BAD_REQUEST, "PROJECT4003", "현재 매칭 중인 프로젝트가 아닙니다."),
 

--- a/src/main/java/com/example/umcmatchingcenter/apiPayload/exception/handler/QnAHandler.java
+++ b/src/main/java/com/example/umcmatchingcenter/apiPayload/exception/handler/QnAHandler.java
@@ -1,0 +1,11 @@
+package com.example.umcmatchingcenter.apiPayload.exception.handler;
+
+import com.example.umcmatchingcenter.apiPayload.code.BaseErrorCode;
+import com.example.umcmatchingcenter.apiPayload.exception.GeneralException;
+
+
+public class QnAHandler extends GeneralException {
+    public QnAHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -35,7 +35,7 @@ public class QnAController {
     /**
      * Q&A 질문 생성
      */
-    @Operation(summary = "Q&A 생성 API")
+    @Operation(summary = "Q&A 질문 생성 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
@@ -60,7 +60,7 @@ public class QnAController {
     /**
      * Q&A 답변 생성
      */
-    @Operation(summary = "Q&A 답변 API")
+    @Operation(summary = "Q&A 답변 생성 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -2,14 +2,12 @@ package com.example.umcmatchingcenter.controller;
 
 import com.example.umcmatchingcenter.apiPayload.ApiResponse;
 import com.example.umcmatchingcenter.converter.QnAConverter;
-import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.Project;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
 import com.example.umcmatchingcenter.service.matchingService.MatchingQueryService;
 import com.example.umcmatchingcenter.service.memberService.MemberQueryService;
-import com.example.umcmatchingcenter.service.projectService.ProjectQueryService;
 import com.example.umcmatchingcenter.service.qnaService.QnACommandService;
 import com.example.umcmatchingcenter.service.qnaService.QnAQueryService;
 import com.example.umcmatchingcenter.validation.annotation.ExistMember;
@@ -27,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -67,6 +64,30 @@ public class QnAController {
     }
 
     /**
+     * Q&A 질문 삭제
+     */
+    @Operation(summary = "Q&A 질문 삭제 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4002", description = "JWT 토큰 만료",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "name 에 맞는 사용자가 없습니다.",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+    })
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/{questionId}")
+    @Parameters({
+            @Parameter(name = "questionId", description = "질문 아이디")
+    })
+    public ApiResponse<String> deleteQnA(
+            @PathVariable(name = "questionId") Long questionId,
+            @Valid @ExistMember Principal principal
+    ){
+        qnaCommandService.deleteQuestion(questionId, principal.getName());
+
+        return ApiResponse.onSuccess(questionId + "번 질문을 삭제했습니다.");
+    }
+
+    /**
      * Q&A 답변 생성
      */
     @Operation(summary = "Q&A 답변 생성 API")
@@ -89,30 +110,6 @@ public class QnAController {
         qnaCommandService.postAnswer(request, questionId, principal.getName());
 
         return ApiResponse.onSuccess(questionId + "번 질문에 답변했습니다.");
-    }
-
-    /**
-     * Q&A 답변 삭제
-     */
-    @Operation(summary = "Q&A 답변 삭제 API")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4002", description = "JWT 토큰 만료",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "name 에 맞는 사용자가 없습니다.",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
-    })
-    @PreAuthorize("isAuthenticated()")
-    @DeleteMapping("/{questionId}")
-    @Parameters({
-            @Parameter(name = "questionId", description = "질문 아이디")
-    })
-    public ApiResponse<String> deleteAnswer(
-            @PathVariable(name = "questionId") Long questionId,
-            @Valid @ExistMember Principal principal
-    ){
-        qnaCommandService.deleteAnswer(questionId, principal.getName());
-
-        return ApiResponse.onSuccess(questionId + "번 질문에 대한 답변을 삭제했습니다.");
     }
 
     /**

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -1,0 +1,63 @@
+package com.example.umcmatchingcenter.controller;
+
+import com.example.umcmatchingcenter.apiPayload.ApiResponse;
+import com.example.umcmatchingcenter.converter.QnAConverter;
+import com.example.umcmatchingcenter.converter.matching.MatchingScheduleConverter;
+import com.example.umcmatchingcenter.domain.Branch;
+import com.example.umcmatchingcenter.domain.MatchingSchedule;
+import com.example.umcmatchingcenter.domain.QnA;
+import com.example.umcmatchingcenter.dto.MatchingDTO.MatchingScheduleRequestDTO;
+import com.example.umcmatchingcenter.dto.MatchingDTO.MatchingScheduleResponseDTO;
+import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
+import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
+import com.example.umcmatchingcenter.service.memberService.MemberQueryService;
+import com.example.umcmatchingcenter.service.qnaService.QnACommandService;
+import com.example.umcmatchingcenter.validation.annotation.ExistMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Q&A API")
+@RequestMapping("/qna")
+public class QnAController {
+
+    private final MemberQueryService memberQueryService;
+    private final QnACommandService qnaCommandService;
+
+    /**
+     * Q&A 질문 생성
+     */
+    @Operation(summary = "Q&A 생성 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4002", description = "JWT 토큰 만료",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "name 에 맞는 사용자가 없습니다.",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+    })
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/{projectId}")
+    @Parameters({
+            @Parameter(name = "projectId", description = "매칭 프로젝트 아이디")
+    })
+    public ApiResponse<QnAResponseDTO.QnAResultDTO> postQnA (
+            @PathVariable(name = "projectId") Long projectId,
+            @RequestBody @Valid QnARequestDTO.QnADTO request,
+            @Valid @ExistMember Principal principal
+    ){
+        QnA qna = qnaCommandService.postQnA(request, projectId);
+
+        return ApiResponse.onSuccess(QnAConverter.toPostQnAResultDTO(qna));
+    }
+}

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -56,4 +56,29 @@ public class QnAController {
 
         return ApiResponse.onSuccess(QnAConverter.toPostQuestionResultDTO(qna));
     }
+
+    /**
+     * Q&A 답변 생성
+     */
+    @Operation(summary = "Q&A 답변 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4002", description = "JWT 토큰 만료",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "name 에 맞는 사용자가 없습니다.",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+    })
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/{questionId}")
+    @Parameters({
+            @Parameter(name = "questionId", description = "질문 아이디")
+    })
+    public ApiResponse<String> postAnswer(
+            @PathVariable(name = "questionId") Long questionId,
+            @RequestBody @Valid QnARequestDTO.answerDTO request,
+            @Valid @ExistMember Principal principal
+    ){
+        qnaCommandService.postAnswer(request, questionId, principal.getName());
+
+        return ApiResponse.onSuccess(questionId + "번 질문에 답변했습니다.");
+    }
 }

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -81,4 +81,28 @@ public class QnAController {
 
         return ApiResponse.onSuccess(questionId + "번 질문에 답변했습니다.");
     }
+
+    /**
+     * Q&A 답변 삭제
+     */
+    @Operation(summary = "Q&A 답변 삭제 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4002", description = "JWT 토큰 만료",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "name 에 맞는 사용자가 없습니다.",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+    })
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/{questionId}")
+    @Parameters({
+            @Parameter(name = "questionId", description = "질문 아이디")
+    })
+    public ApiResponse<String> deleteAnswer(
+            @PathVariable(name = "questionId") Long questionId,
+            @Valid @ExistMember Principal principal
+    ){
+        qnaCommandService.deleteAnswer(questionId, principal.getName());
+
+        return ApiResponse.onSuccess(questionId + "번 질문에 대한 답변을 삭제했습니다.");
+    }
 }

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -131,7 +131,7 @@ public class QnAController {
             @PathVariable(name = "projectId") Long projectId,
             @Valid @ExistMember Principal principal
     ){
-        Project project = matchingQueryService.findProjectByProjectId(projectId);
+        Project project = matchingQueryService.findProject(projectId);
         List<QnA> qnaList = qnaQueryService.getQnAList(project);
 
         return ApiResponse.onSuccess(QnAConverter.toQnAPreViewListDTO(qnaList));

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -2,6 +2,7 @@ package com.example.umcmatchingcenter.controller;
 
 import com.example.umcmatchingcenter.apiPayload.ApiResponse;
 import com.example.umcmatchingcenter.converter.QnAConverter;
+import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
@@ -51,7 +52,7 @@ public class QnAController {
             @RequestBody @Valid QnARequestDTO.questionDTO request,
             @Valid @ExistMember Principal principal
     ){
-        QnA qna = qnaCommandService.postQuestion(request, projectId);
+        QnA qna = qnaCommandService.postQuestion(request, projectId, principal.getName());
 
         return ApiResponse.onSuccess(QnAConverter.toPostQuestionResultDTO(qna));
     }

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -2,12 +2,7 @@ package com.example.umcmatchingcenter.controller;
 
 import com.example.umcmatchingcenter.apiPayload.ApiResponse;
 import com.example.umcmatchingcenter.converter.QnAConverter;
-import com.example.umcmatchingcenter.converter.matching.MatchingScheduleConverter;
-import com.example.umcmatchingcenter.domain.Branch;
-import com.example.umcmatchingcenter.domain.MatchingSchedule;
 import com.example.umcmatchingcenter.domain.QnA;
-import com.example.umcmatchingcenter.dto.MatchingDTO.MatchingScheduleRequestDTO;
-import com.example.umcmatchingcenter.dto.MatchingDTO.MatchingScheduleResponseDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
 import com.example.umcmatchingcenter.service.memberService.MemberQueryService;
@@ -51,13 +46,13 @@ public class QnAController {
     @Parameters({
             @Parameter(name = "projectId", description = "매칭 프로젝트 아이디")
     })
-    public ApiResponse<QnAResponseDTO.QnAResultDTO> postQnA (
+    public ApiResponse<QnAResponseDTO.questionResultDTO> postQuestion(
             @PathVariable(name = "projectId") Long projectId,
-            @RequestBody @Valid QnARequestDTO.QnADTO request,
+            @RequestBody @Valid QnARequestDTO.questionDTO request,
             @Valid @ExistMember Principal principal
     ){
-        QnA qna = qnaCommandService.postQnA(request, projectId);
+        QnA qna = qnaCommandService.postQuestion(request, projectId);
 
-        return ApiResponse.onSuccess(QnAConverter.toPostQnAResultDTO(qna));
+        return ApiResponse.onSuccess(QnAConverter.toPostQuestionResultDTO(qna));
     }
 }

--- a/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
+++ b/src/main/java/com/example/umcmatchingcenter/controller/QnAController.java
@@ -3,11 +3,15 @@ package com.example.umcmatchingcenter.controller;
 import com.example.umcmatchingcenter.apiPayload.ApiResponse;
 import com.example.umcmatchingcenter.converter.QnAConverter;
 import com.example.umcmatchingcenter.domain.Member;
+import com.example.umcmatchingcenter.domain.Project;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
+import com.example.umcmatchingcenter.service.matchingService.MatchingQueryService;
 import com.example.umcmatchingcenter.service.memberService.MemberQueryService;
+import com.example.umcmatchingcenter.service.projectService.ProjectQueryService;
 import com.example.umcmatchingcenter.service.qnaService.QnACommandService;
+import com.example.umcmatchingcenter.service.qnaService.QnAQueryService;
 import com.example.umcmatchingcenter.validation.annotation.ExistMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,6 +26,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +36,10 @@ import java.security.Principal;
 public class QnAController {
 
     private final MemberQueryService memberQueryService;
+    private final MatchingQueryService matchingQueryService;
+
     private final QnACommandService qnaCommandService;
+    private final QnAQueryService qnaQueryService;
 
     /**
      * Q&A 질문 생성
@@ -104,5 +113,30 @@ public class QnAController {
         qnaCommandService.deleteAnswer(questionId, principal.getName());
 
         return ApiResponse.onSuccess(questionId + "번 질문에 대한 답변을 삭제했습니다.");
+    }
+
+    /**
+     * Q&A 목록 조회
+     */
+    @Operation(summary = "특정 프로젝트의 Q&A 목록 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4001", description = "JWT 토큰을 주세요!",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "JWT4002", description = "JWT 토큰 만료",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "name 에 맞는 사용자가 없습니다.",content = @Content(schema = @Schema(implementation = io.swagger.v3.oas.annotations.responses.ApiResponse.class))),
+    })
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/{projectId}")
+    @Parameters({
+            @Parameter(name = "projectId", description = "프로젝트 아이디")
+    })
+    public ApiResponse<QnAResponseDTO.QnAListDTO> getQnAList(
+            @PathVariable(name = "projectId") Long projectId,
+            @Valid @ExistMember Principal principal
+    ){
+        Project project = matchingQueryService.findProjectByProjectId(projectId);
+        List<QnA> qnaList = qnaQueryService.getQnAList(project);
+
+        return ApiResponse.onSuccess(QnAConverter.toQnAPreViewListDTO(qnaList));
     }
 }

--- a/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
+++ b/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
@@ -6,6 +6,10 @@ import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
 
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class QnAConverter {
     // Q&A 생성 (질문하기)
     public static QnAResponseDTO.questionResultDTO toPostQuestionResultDTO(QnA qna) {
@@ -22,4 +26,25 @@ public class QnAConverter {
                 .question(request.getQuestion())
                 .build();
     }
+
+    // Q&A 리스트 조회
+    public static QnAResponseDTO.QnAPreViewDTO toQnAPreViewDTO(QnA qna) {
+        return QnAResponseDTO.QnAPreViewDTO.builder()
+                .questionId(qna.getId())
+                .question(qna.getQuestion())
+                .answer(qna.getAnswer())
+                .createdAt(qna.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm")))
+                .build();
+    }
+
+    public static QnAResponseDTO.QnAListDTO toQnAPreViewListDTO(List<QnA> qnaList) {
+
+        List<QnAResponseDTO.QnAPreViewDTO> qnAPreViewDTOList =  qnaList.stream()
+                .map(QnAConverter::toQnAPreViewDTO).collect(Collectors.toList());
+
+        return QnAResponseDTO.QnAListDTO.builder()
+                .qnaList(qnAPreViewDTOList)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
+++ b/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
@@ -1,0 +1,26 @@
+package com.example.umcmatchingcenter.converter;
+
+import com.example.umcmatchingcenter.domain.Project;
+import com.example.umcmatchingcenter.domain.QnA;
+import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
+import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
+
+import java.util.Optional;
+
+public class QnAConverter {
+    // Q&A 생성
+    public static QnAResponseDTO.QnAResultDTO toPostQnAResultDTO(QnA qna) {
+        return QnAResponseDTO.QnAResultDTO.builder()
+                .questionId(qna.getId())
+                .build();
+    }
+
+    public static QnA toQnA(QnARequestDTO.QnADTO request, Project project) {
+
+        return QnA.builder()
+                .project(project)
+//                .pm(project.getPm())
+                .question(request.getQuestion())
+                .build();
+    }
+}

--- a/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
+++ b/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
@@ -5,17 +5,15 @@ import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.dto.QnADTO.QnAResponseDTO;
 
-import java.util.Optional;
-
 public class QnAConverter {
-    // Q&A 생성
-    public static QnAResponseDTO.QnAResultDTO toPostQnAResultDTO(QnA qna) {
-        return QnAResponseDTO.QnAResultDTO.builder()
+    // Q&A 생성 (질문하기)
+    public static QnAResponseDTO.questionResultDTO toPostQuestionResultDTO(QnA qna) {
+        return QnAResponseDTO.questionResultDTO.builder()
                 .questionId(qna.getId())
                 .build();
     }
 
-    public static QnA toQnA(QnARequestDTO.QnADTO request, Project project) {
+    public static QnA toQuestion(QnARequestDTO.questionDTO request, Project project) {
 
         return QnA.builder()
                 .project(project)

--- a/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
+++ b/src/main/java/com/example/umcmatchingcenter/converter/QnAConverter.java
@@ -1,5 +1,6 @@
 package com.example.umcmatchingcenter.converter;
 
+import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.Project;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
@@ -13,11 +14,11 @@ public class QnAConverter {
                 .build();
     }
 
-    public static QnA toQuestion(QnARequestDTO.questionDTO request, Project project) {
+    public static QnA toQuestion(QnARequestDTO.questionDTO request, Project project, Member inquirer) {
 
         return QnA.builder()
                 .project(project)
-//                .pm(project.getPm())
+                .inquirer(inquirer)
                 .question(request.getQuestion())
                 .build();
     }

--- a/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
@@ -19,9 +19,13 @@ public class QnA extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "pm_id")
+//    private Member pm;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "pm_id")
-    private Member pm;
+    @JoinColumn(name = "project_id")
+    private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "inquirer_id")

--- a/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
@@ -1,0 +1,36 @@
+package com.example.umcmatchingcenter.domain;
+
+import com.example.umcmatchingcenter.domain.common.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class QnA extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pm_id")
+    private Member pm;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inquirer_id")
+    private Member inquirer;
+
+    @Column(nullable = false)
+    private String question;
+
+    @Column
+    private String answer;
+
+}

--- a/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
@@ -41,8 +41,4 @@ public class QnA extends BaseEntity {
         this.answer = answer;
     }
 
-    public void deleteAnswer() {
-        this.answer = null;
-    }
-
 }

--- a/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
@@ -37,4 +37,8 @@ public class QnA extends BaseEntity {
     @Column
     private String answer;
 
+    public void updateAnswer(String answer) {
+        this.answer = answer;
+    }
+
 }

--- a/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/QnA.java
@@ -41,4 +41,8 @@ public class QnA extends BaseEntity {
         this.answer = answer;
     }
 
+    public void deleteAnswer() {
+        this.answer = null;
+    }
+
 }

--- a/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnARequestDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnARequestDTO.java
@@ -7,11 +7,9 @@ import javax.validation.constraints.NotNull;
 
 public class QnARequestDTO {
     @Getter
-    public static class QnADTO {
-
+    public static class questionDTO {
         @NotNull
         @Schema(description = "질문 내용", example = "질문 내용")
         String question;
-
     }
 }

--- a/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnARequestDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnARequestDTO.java
@@ -12,4 +12,11 @@ public class QnARequestDTO {
         @Schema(description = "질문 내용", example = "질문 내용")
         String question;
     }
+
+    @Getter
+    public static class answerDTO {
+        @NotNull
+        @Schema(description = "답변 내용", example = "답변 내용")
+        String answer;
+    }
 }

--- a/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnARequestDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnARequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.umcmatchingcenter.dto.QnADTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+public class QnARequestDTO {
+    @Getter
+    public static class QnADTO {
+
+        @NotNull
+        @Schema(description = "질문 내용", example = "질문 내용")
+        String question;
+
+    }
+}

--- a/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnAResponseDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnAResponseDTO.java
@@ -11,7 +11,7 @@ public class QnAResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class QnAResultDTO {
+    public static class questionResultDTO {
         private Long questionId;
     }
 

--- a/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnAResponseDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnAResponseDTO.java
@@ -1,9 +1,12 @@
 package com.example.umcmatchingcenter.dto.QnADTO;
 
+import com.example.umcmatchingcenter.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class QnAResponseDTO {
 
@@ -13,6 +16,26 @@ public class QnAResponseDTO {
     @AllArgsConstructor
     public static class questionResultDTO {
         private Long questionId;
+    }
+
+    // Q&A 목록 조회
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QnAListDTO {
+        private List<QnAPreViewDTO> qnaList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QnAPreViewDTO {
+        private Long questionId;
+        private String question;
+        private String answer;
+        private String createdAt;
     }
 
 }

--- a/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnAResponseDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/QnADTO/QnAResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.umcmatchingcenter.dto.QnADTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class QnAResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QnAResultDTO {
+        private Long questionId;
+    }
+
+}

--- a/src/main/java/com/example/umcmatchingcenter/repository/QnARepository.java
+++ b/src/main/java/com/example/umcmatchingcenter/repository/QnARepository.java
@@ -1,0 +1,9 @@
+package com.example.umcmatchingcenter.repository;
+
+import com.example.umcmatchingcenter.domain.Project;
+import com.example.umcmatchingcenter.domain.QnA;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QnARepository extends JpaRepository<QnA, Long> {
+    QnA findQnAByProject(Project project);
+}

--- a/src/main/java/com/example/umcmatchingcenter/repository/QnARepository.java
+++ b/src/main/java/com/example/umcmatchingcenter/repository/QnARepository.java
@@ -4,6 +4,10 @@ import com.example.umcmatchingcenter.domain.Project;
 import com.example.umcmatchingcenter.domain.QnA;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QnARepository extends JpaRepository<QnA, Long> {
     QnA findQnAByProject(Project project);
+
+    List<QnA> findAllByProjectOrderByCreatedAt(Project project);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryService.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface MatchingQueryService {
     Optional<Project> findProject(Long id);
 
+    Project findProjectByProjectId(Long id);
+
     List<Project> getProjectList(Branch branch, ProjectStatus status, Integer page);
 
     // TODO: 작성자(pm)가 나인지 확인

--- a/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryService.java
@@ -8,9 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MatchingQueryService {
-    Optional<Project> findProject(Long id);
-
-    Project findProjectByProjectId(Long id);
+    Project findProject(Long id);
 
     List<Project> getProjectList(Branch branch, ProjectStatus status, Integer page);
 

--- a/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryServiceImpl.java
@@ -29,6 +29,11 @@ public class MatchingQueryServiceImpl implements MatchingQueryService {
     }
 
     @Override
+    public Project findProjectByProjectId(Long id) {
+        return matchingRepository.findById(id).get();
+    }
+
+    @Override
     public List<Project> getProjectList(Branch branch, ProjectStatus status, Integer page) {
         try {
             return matchingRepository.findAllByBranchAndStatusOrderByCreatedAt(branch, status, PageRequest.of(page, PAGING_SIZE)).getContent();

--- a/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/matchingService/MatchingQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.umcmatchingcenter.service.matchingService;
 
 import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.MatchingHandler;
 import com.example.umcmatchingcenter.apiPayload.exception.handler.ProjectHandler;
 import com.example.umcmatchingcenter.domain.Branch;
 import com.example.umcmatchingcenter.domain.Project;
@@ -24,14 +25,14 @@ public class MatchingQueryServiceImpl implements MatchingQueryService {
     private final MatchingRepository matchingRepository;
 
     @Override
-    public Optional<Project> findProject(Long id) {
-        return matchingRepository.findById(id);
+    public Project findProject(Long id) {
+        Optional<Project> project = matchingRepository.findById(id);
+        if (project.isEmpty()) {
+            throw new ProjectHandler(ErrorStatus.PROJECT_NOT_EXIST);
+        }
+        return project.get();
     }
 
-    @Override
-    public Project findProjectByProjectId(Long id) {
-        return matchingRepository.findById(id).get();
-    }
 
     @Override
     public List<Project> getProjectList(Branch branch, ProjectStatus status, Integer page) {

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -1,7 +1,5 @@
 package com.example.umcmatchingcenter.service.qnaService;
 
-import com.example.umcmatchingcenter.domain.Branch;
-import com.example.umcmatchingcenter.domain.MatchingSchedule;
 import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
@@ -16,7 +14,7 @@ public interface QnACommandService {
     public abstract void postAnswer(QnARequestDTO.answerDTO request, Long questionId, String respondentName);
 
     @Transactional
-    public abstract void deleteAnswer(Long questionId, String respondentName);
+    public abstract void deleteQuestion(Long questionId, String respondentName);
 
     public abstract QnA checkIsAuthorized(Long questionId, Member member);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -7,5 +7,5 @@ import org.springframework.transaction.annotation.Transactional;
 public interface QnACommandService {
 
     @Transactional
-    public abstract QnA postQnA(QnARequestDTO.QnADTO request, Long projectId);
+    public abstract QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -1,5 +1,8 @@
 package com.example.umcmatchingcenter.service.qnaService;
 
+import com.example.umcmatchingcenter.domain.Branch;
+import com.example.umcmatchingcenter.domain.MatchingSchedule;
+import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +11,9 @@ public interface QnACommandService {
 
     @Transactional
     public abstract QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId, String inquirerName);
+
+    @Transactional
+    public abstract void postAnswer(QnARequestDTO.answerDTO request, Long questionId, String respondentName);
+
+    public abstract QnA checkIsAuthorized(Long questionId, Member member);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -1,0 +1,11 @@
+package com.example.umcmatchingcenter.service.qnaService;
+
+import com.example.umcmatchingcenter.domain.QnA;
+import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface QnACommandService {
+
+    @Transactional
+    public abstract QnA postQnA(QnARequestDTO.QnADTO request, Long projectId);
+}

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -15,5 +15,8 @@ public interface QnACommandService {
     @Transactional
     public abstract void postAnswer(QnARequestDTO.answerDTO request, Long questionId, String respondentName);
 
+    @Transactional
+    public abstract void deleteAnswer(Long questionId, String respondentName);
+
     public abstract QnA checkIsAuthorized(Long questionId, Member member);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -7,5 +7,5 @@ import org.springframework.transaction.annotation.Transactional;
 public interface QnACommandService {
 
     @Transactional
-    public abstract QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId);
+    public abstract QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId, String inquirerName);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandService.java
@@ -16,5 +16,5 @@ public interface QnACommandService {
     @Transactional
     public abstract void deleteQuestion(Long questionId, String respondentName);
 
-    public abstract QnA checkIsAuthorized(Long questionId, Member member);
+    public QnA checkIsAuthorized(Long questionId, Member member);
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -1,8 +1,9 @@
 package com.example.umcmatchingcenter.service.qnaService;
 
 import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
-import com.example.umcmatchingcenter.apiPayload.exception.handler.AlarmHandler;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.MemberHandler;
 import com.example.umcmatchingcenter.apiPayload.exception.handler.ProjectHandler;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.QnAHandler;
 import com.example.umcmatchingcenter.converter.QnAConverter;
 import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.Project;
@@ -29,7 +30,7 @@ public class QnACommandServiceImpl implements QnACommandService {
     @Override
     public QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId, String memberName) {
         Member inquirer = memberRepository.findByMemberName(memberName)
-                .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(()-> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Optional<Project> findProject = matchingRepository.findById(projectId);
 
         if (findProject.isPresent()) {
@@ -38,6 +39,37 @@ public class QnACommandServiceImpl implements QnACommandService {
             return qnaRepository.save(newQnA);
         } else {
             throw new ProjectHandler(ErrorStatus.PROJECT_NOT_PROCEEDING);
+        }
+    }
+
+    @Override
+    public void postAnswer(QnARequestDTO.answerDTO request, Long questionId, String respondentName) {
+        Member respondent = memberRepository.findByMemberName(respondentName)
+                .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        // 답변 권한 확인
+        QnA findQuestion = checkIsAuthorized(questionId, respondent);
+        // 답변 생성
+        findQuestion.updateAnswer(request.getAnswer());
+        qnaRepository.save(findQuestion);
+    }
+
+    @Override
+    public QnA checkIsAuthorized(Long questionId, Member member) {
+        Optional<QnA> findOptionalQuestion = qnaRepository.findById(questionId);
+
+        // 질문 존재 여부 확인
+        if (findOptionalQuestion.isPresent()) {
+
+            QnA question = findOptionalQuestion.get();
+
+            // 답변 권한 확인
+            if (!member.equals(question.getProject().getPm())) {
+                throw new QnAHandler(ErrorStatus.ANSWER_UNAUTHORIZED);
+            }
+            return question;
+
+        } else {
+            throw new QnAHandler(ErrorStatus.QUESTION_NOT_FOUNT);
         }
     }
 }

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.repository.MatchingRepository;
 import com.example.umcmatchingcenter.repository.MemberRepository;
 import com.example.umcmatchingcenter.repository.QnARepository;
+import com.example.umcmatchingcenter.service.memberService.MemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,14 +24,14 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class QnACommandServiceImpl implements QnACommandService {
 
-    private final MemberRepository memberRepository;
     private final QnARepository qnaRepository;
     private final MatchingRepository matchingRepository;
 
+    private final MemberQueryService memberQueryService;
+
     @Override
     public QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId, String memberName) {
-        Member inquirer = memberRepository.findByMemberName(memberName)
-                .orElseThrow(()-> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member inquirer = memberQueryService.findMemberByName(memberName);
         Optional<Project> findProject = matchingRepository.findById(projectId);
 
         if (findProject.isPresent()) {
@@ -44,8 +45,7 @@ public class QnACommandServiceImpl implements QnACommandService {
 
     @Override
     public void postAnswer(QnARequestDTO.answerDTO request, Long questionId, String respondentName) {
-        Member respondent = memberRepository.findByMemberName(respondentName)
-                .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member respondent = memberQueryService.findMemberByName(respondentName);
         // 답변 권한 확인
         QnA findQuestion = checkIsAuthorized(questionId, respondent);
         // 답변 생성
@@ -55,8 +55,7 @@ public class QnACommandServiceImpl implements QnACommandService {
 
     @Override
     public void deleteQuestion(Long questionId, String respondentName) {
-        Member respondent = memberRepository.findByMemberName(respondentName)
-                .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member respondent = memberQueryService.findMemberByName(respondentName);
         // 답변 권한 확인
         checkIsAuthorized(questionId, respondent);
         // Q&A 질문 삭제

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -1,0 +1,37 @@
+package com.example.umcmatchingcenter.service.qnaService;
+
+import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.MatchingHandler;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.ProjectHandler;
+import com.example.umcmatchingcenter.converter.QnAConverter;
+import com.example.umcmatchingcenter.domain.Project;
+import com.example.umcmatchingcenter.domain.QnA;
+import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
+import com.example.umcmatchingcenter.repository.MatchingRepository;
+import com.example.umcmatchingcenter.repository.QnARepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QnACommandServiceImpl implements QnACommandService {
+
+    private final QnARepository qnaRepository;
+    private final MatchingRepository matchingRepository;
+
+    @Override
+    public QnA postQnA(QnARequestDTO.QnADTO request, Long projectId) {
+        Optional<Project> findProject = matchingRepository.findById(projectId);
+        if (findProject.isPresent()) {
+            Project project = findProject.get();
+            QnA newQnA = QnAConverter.toQnA(request, project);
+            return qnaRepository.save(newQnA);
+        } else {
+            throw new ProjectHandler(ErrorStatus.PROJECT_NOT_PROCEEDING);
+        }
+    }
+}

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -54,6 +54,17 @@ public class QnACommandServiceImpl implements QnACommandService {
     }
 
     @Override
+    public void deleteAnswer(Long questionId, String respondentName) {
+        Member respondent = memberRepository.findByMemberName(respondentName)
+                .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        // 답변 권한 확인
+        QnA findQuestion = checkIsAuthorized(questionId, respondent);
+        // 답변 삭제
+        findQuestion.deleteAnswer();
+        qnaRepository.save(findQuestion);
+    }
+
+    @Override
     public QnA checkIsAuthorized(Long questionId, Member member) {
         Optional<QnA> findOptionalQuestion = qnaRepository.findById(questionId);
 

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.umcmatchingcenter.service.qnaService;
 
 import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
-import com.example.umcmatchingcenter.apiPayload.exception.handler.MatchingHandler;
 import com.example.umcmatchingcenter.apiPayload.exception.handler.ProjectHandler;
 import com.example.umcmatchingcenter.converter.QnAConverter;
 import com.example.umcmatchingcenter.domain.Project;
@@ -24,11 +23,11 @@ public class QnACommandServiceImpl implements QnACommandService {
     private final MatchingRepository matchingRepository;
 
     @Override
-    public QnA postQnA(QnARequestDTO.QnADTO request, Long projectId) {
+    public QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId) {
         Optional<Project> findProject = matchingRepository.findById(projectId);
         if (findProject.isPresent()) {
             Project project = findProject.get();
-            QnA newQnA = QnAConverter.toQnA(request, project);
+            QnA newQnA = QnAConverter.toQuestion(request, project);
             return qnaRepository.save(newQnA);
         } else {
             throw new ProjectHandler(ErrorStatus.PROJECT_NOT_PROCEEDING);

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -1,12 +1,15 @@
 package com.example.umcmatchingcenter.service.qnaService;
 
 import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.AlarmHandler;
 import com.example.umcmatchingcenter.apiPayload.exception.handler.ProjectHandler;
 import com.example.umcmatchingcenter.converter.QnAConverter;
+import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.Project;
 import com.example.umcmatchingcenter.domain.QnA;
 import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
 import com.example.umcmatchingcenter.repository.MatchingRepository;
+import com.example.umcmatchingcenter.repository.MemberRepository;
 import com.example.umcmatchingcenter.repository.QnARepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,15 +22,19 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class QnACommandServiceImpl implements QnACommandService {
 
+    private final MemberRepository memberRepository;
     private final QnARepository qnaRepository;
     private final MatchingRepository matchingRepository;
 
     @Override
-    public QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId) {
+    public QnA postQuestion(QnARequestDTO.questionDTO request, Long projectId, String memberName) {
+        Member inquirer = memberRepository.findByMemberName(memberName)
+                .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Optional<Project> findProject = matchingRepository.findById(projectId);
+
         if (findProject.isPresent()) {
             Project project = findProject.get();
-            QnA newQnA = QnAConverter.toQuestion(request, project);
+            QnA newQnA = QnAConverter.toQuestion(request, project, inquirer);
             return qnaRepository.save(newQnA);
         } else {
             throw new ProjectHandler(ErrorStatus.PROJECT_NOT_PROCEEDING);

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnACommandServiceImpl.java
@@ -54,14 +54,13 @@ public class QnACommandServiceImpl implements QnACommandService {
     }
 
     @Override
-    public void deleteAnswer(Long questionId, String respondentName) {
+    public void deleteQuestion(Long questionId, String respondentName) {
         Member respondent = memberRepository.findByMemberName(respondentName)
                 .orElseThrow(()-> new ProjectHandler(ErrorStatus.MEMBER_NOT_FOUND));
         // 답변 권한 확인
-        QnA findQuestion = checkIsAuthorized(questionId, respondent);
-        // 답변 삭제
-        findQuestion.deleteAnswer();
-        qnaRepository.save(findQuestion);
+        checkIsAuthorized(questionId, respondent);
+        // Q&A 질문 삭제
+        qnaRepository.deleteById(questionId);
     }
 
     @Override

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnAQueryService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnAQueryService.java
@@ -1,10 +1,7 @@
 package com.example.umcmatchingcenter.service.qnaService;
 
-import com.example.umcmatchingcenter.domain.Member;
 import com.example.umcmatchingcenter.domain.Project;
 import com.example.umcmatchingcenter.domain.QnA;
-import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnAQueryService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnAQueryService.java
@@ -1,0 +1,13 @@
+package com.example.umcmatchingcenter.service.qnaService;
+
+import com.example.umcmatchingcenter.domain.Member;
+import com.example.umcmatchingcenter.domain.Project;
+import com.example.umcmatchingcenter.domain.QnA;
+import com.example.umcmatchingcenter.dto.QnADTO.QnARequestDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface QnAQueryService {
+    List<QnA> getQnAList(Project project);
+}

--- a/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnAQueryServiceImpl.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/qnaService/QnAQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.example.umcmatchingcenter.service.qnaService;
+
+import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.ProjectHandler;
+import com.example.umcmatchingcenter.domain.Project;
+import com.example.umcmatchingcenter.domain.QnA;
+import com.example.umcmatchingcenter.repository.QnARepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QnAQueryServiceImpl implements QnAQueryService {
+
+    private final QnARepository qnaRepository;
+
+    @Override
+    public List<QnA> getQnAList(Project project) {
+        try {
+            return qnaRepository.findAllByProjectOrderByCreatedAt(project);
+        } catch (Exception e) {
+            throw new ProjectHandler(ErrorStatus.PROJECT_NOT_EXIST);
+        }
+    }
+}


### PR DESCRIPTION
## 개요
<!---- Resolves: #(Isuue Number) -->
- 관련 이슈:  #82 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존의 1:1 채팅에서 Q&A로 기획이 변경됨에 따라 Q&A 관련 API를 구현했습니다.
채팅에서 pm과 다대다로 설정되어 있던 연관관계를 pm이 아니라 프로젝트와 다대다 관계를 가지도록 했습니다.
Q&A의 경우에는 질문과 답변이 일대일 관계라고 해서, QnA 테이블의 필드에 질문과 답변을 한번에 넣는 식으로 진행했습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CI/CD
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/UMC-Matching-Center/U.M.C_Server?tab=readme-ov-file#-commit-message-convension)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
