### PR TITLE
🐛 Fix/92 날짜 저장 형식 자릿수 맞추기

### DIFF
--- a/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
@@ -14,6 +14,8 @@ import javax.persistence.*;
 @Builder
 public class MatchingSchedule extends BaseEntity {
 
+    public static final String DATE_DIVIDER = "-";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -45,13 +47,13 @@ public class MatchingSchedule extends BaseEntity {
     }
 
     public static String combineDate(Integer year, Integer month, Integer day) {
-        return "20" + year + "-" + String.format("%02d", month) + "-" + String.format("%02d", day);
+        return "20" + year + DATE_DIVIDER + String.format("%02d", month) + DATE_DIVIDER + String.format("%02d", day);
     }
 
     public static Integer splitDate(String str, int i) {
-        String[] date = str.split("-");
+        String[] date = str.split(DATE_DIVIDER);
         String current = date[i];
-        current = current.substring(current.length()-2, current.length());
+        current = current.substring(current.length()-2);
         return Integer.parseInt(current);
     }
 }

--- a/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
@@ -14,7 +14,9 @@ import javax.persistence.*;
 @Builder
 public class MatchingSchedule extends BaseEntity {
 
+    public static final String CENTURY_PREFIX = "20";
     public static final String DATE_DIVIDER = "-";
+    public static final String DATE_PATTERN = "%02d";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,7 +49,7 @@ public class MatchingSchedule extends BaseEntity {
     }
 
     public static String combineDate(Integer year, Integer month, Integer day) {
-        return "20" + year + DATE_DIVIDER + String.format("%02d", month) + DATE_DIVIDER + String.format("%02d", day);
+        return CENTURY_PREFIX + year + DATE_DIVIDER + String.format(DATE_PATTERN, month) + DATE_DIVIDER + String.format(DATE_PATTERN, day);
     }
 
     public static Integer splitDate(String str, int i) {

--- a/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
@@ -40,12 +40,12 @@ public class MatchingSchedule extends BaseEntity {
         this.name = schedule.getTitle();
         this.description = schedule.getDescription();
         this.scheduleColor = schedule.getScheduleColor();
-        this.startDate = combineDate(schedule.getStartYear(), schedule.getStartMonth(), schedule.getEndYear());
+        this.startDate = combineDate(schedule.getStartYear(), schedule.getStartMonth(), schedule.getStartDay());
         this.endDate = combineDate(schedule.getEndYear(), schedule.getEndMonth(), schedule.getEndDay());
     }
 
     public static String combineDate(Integer year, Integer month, Integer day) {
-        return "20" + year + "-" + month + "-" + day;
+        return "20" + year + "-" + String.format("%02d", month) + "-" + String.format("%02d", day);
     }
 
     public static Integer splitDate(String str, int i) {


### PR DESCRIPTION
Related to: #92
Fixes: #54

## 개요
<!---- Resolves: #(Isuue Number) -->
- 관련 이슈: #92 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
날짜 형식이 이상하게 들어가서 조회할 때 오류가 발생했습니다. yyyy-MM-dd 형식으로 자릿수에 맞춰서 들어갈 수 있도록 수정했습니다.


## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI/CD
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/UMC-Matching-Center/U.M.C_Server?tab=readme-ov-file#-commit-message-convension)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
