### PR TITLE
♻️ Refactor/97 매칭 일정 색상을 hexCode로 변경

### DIFF
--- a/src/main/java/com/example/umcmatchingcenter/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/umcmatchingcenter/apiPayload/code/status/ErrorStatus.java
@@ -53,6 +53,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 매칭 일정 관련 에러
     MATCHINGSCHEDULE_NOT_EXIST(BAD_REQUEST, "SCHEDULE4001", "매칭 일정이 없습니다."),
     MATCHINGSCHEDULE_UNAUTHORIZED(BAD_REQUEST, "SCHEDULE4002", "해당 매칭 일정에 대한 권한이 없습니다."),
+    MATCHINGSCHEDULE_COLOR_NOT_EXIST(BAD_REQUEST, "SCHEDULE4003", "유효하지 않은 색상입니다."),
 
     //공지사항
     NOTICE_NOT_EXIST(HttpStatus.BAD_REQUEST, "NOTICE4001", "공지사항이 없습니다."),

--- a/src/main/java/com/example/umcmatchingcenter/converter/matching/MatchingScheduleConverter.java
+++ b/src/main/java/com/example/umcmatchingcenter/converter/matching/MatchingScheduleConverter.java
@@ -2,6 +2,7 @@ package com.example.umcmatchingcenter.converter.matching;
 
 import com.example.umcmatchingcenter.domain.Branch;
 import com.example.umcmatchingcenter.domain.MatchingSchedule;
+import com.example.umcmatchingcenter.domain.enums.ScheduleColor;
 import com.example.umcmatchingcenter.dto.MatchingDTO.MatchingScheduleRequestDTO;
 import com.example.umcmatchingcenter.dto.MatchingDTO.MatchingScheduleResponseDTO;
 
@@ -20,7 +21,7 @@ public class MatchingScheduleConverter {
 
         return MatchingSchedule.builder()
                 .branch(branch)
-                .scheduleColor(request.getScheduleColor())
+                .scheduleColor(ScheduleColor.fromHexCode(request.getScheduleColor()))
                 .startDate(MatchingSchedule.combineDate(request.getStartYear(), request.getStartMonth(), request.getStartDay()))
                 .endDate(MatchingSchedule.combineDate(request.getEndYear(), request.getEndMonth(), request.getEndDay()))
                 .name(request.getTitle())
@@ -34,7 +35,7 @@ public class MatchingScheduleConverter {
                 .scheduleId(schedule.getId())
                 .title(schedule.getName())
                 .description(schedule.getDescription())
-                .scheduleColor(schedule.getScheduleColor().getColor())
+                .scheduleColor(schedule.getScheduleColor().getHexColor())
                 .startYear(MatchingSchedule.splitDate(schedule.getStartDate(), 0))
                 .startMonth(MatchingSchedule.splitDate(schedule.getStartDate(), 1))
                 .startDay(MatchingSchedule.splitDate(schedule.getStartDate(), 2))

--- a/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/MatchingSchedule.java
@@ -43,7 +43,7 @@ public class MatchingSchedule extends BaseEntity {
     public void updateSchedule(MatchingScheduleRequestDTO.MatchingScheduleDTO schedule) {
         this.name = schedule.getTitle();
         this.description = schedule.getDescription();
-        this.scheduleColor = schedule.getScheduleColor();
+        this.scheduleColor = ScheduleColor.fromHexCode(schedule.getScheduleColor());
         this.startDate = combineDate(schedule.getStartYear(), schedule.getStartMonth(), schedule.getStartDay());
         this.endDate = combineDate(schedule.getEndYear(), schedule.getEndMonth(), schedule.getEndDay());
     }

--- a/src/main/java/com/example/umcmatchingcenter/domain/enums/ScheduleColor.java
+++ b/src/main/java/com/example/umcmatchingcenter/domain/enums/ScheduleColor.java
@@ -1,5 +1,8 @@
 package com.example.umcmatchingcenter.domain.enums;
 
+import com.example.umcmatchingcenter.apiPayload.code.status.ErrorStatus;
+import com.example.umcmatchingcenter.apiPayload.exception.handler.MatchingHandler;
+
 public enum ScheduleColor {
     WHITE("#DCDEEE"),
     RED("#FF7676"),
@@ -17,7 +20,17 @@ public enum ScheduleColor {
         this.hexColor = color;
     }
 
-    public String getColor() {
+    public String getHexColor() {
         return hexColor;
     }
+
+    public static ScheduleColor fromHexCode(String hexCode) {
+        for (ScheduleColor color : values()) {
+            if (color.getHexColor().equalsIgnoreCase(hexCode)) {
+                return color;
+            }
+        }
+        throw new MatchingHandler(ErrorStatus.MATCHINGSCHEDULE_COLOR_NOT_EXIST);
+    }
+
 }

--- a/src/main/java/com/example/umcmatchingcenter/dto/MatchingDTO/MatchingScheduleRequestDTO.java
+++ b/src/main/java/com/example/umcmatchingcenter/dto/MatchingDTO/MatchingScheduleRequestDTO.java
@@ -35,15 +35,13 @@ public class MatchingScheduleRequestDTO {
         @Schema(description = "종료일", example = "01")
         Integer endDay;
 
-
-
 //        @Schema(description = "시작일", example = "2024-01-25")
 //        String startDate;
 //
 //        @Schema(description = "종료일", example = "2024-02-01")
 //        String endDate;
 
-        @Schema(description = "일정 색상", example = "일정 색상 (WHITE, RED, ORANGE, ..)")
-        ScheduleColor scheduleColor;
+        @Schema(description = "일정 색상", example = "#DCDEEE")
+        String scheduleColor;
     }
 }


### PR DESCRIPTION
Related to: #97
Fixes: #54

## 개요
<!---- Resolves: #(Isuue Number) -->
- 관련 이슈: #97 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
프론트의 요청 사항에 따라 색상을 색상 이름의 Enum이 아니라 hexCode로 받게 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CI/CD
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/UMC-Matching-Center/U.M.C_Server?tab=readme-ov-file#-commit-message-convension)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
