### PR TITLE
🐛 [bug] 챌린저 조회시 탈퇴 회원 비조회

### DIFF
--- a/src/main/java/com/example/umcmatchingcenter/repository/MemberRepository.java
+++ b/src/main/java/com/example/umcmatchingcenter/repository/MemberRepository.java
@@ -6,12 +6,10 @@ import com.example.umcmatchingcenter.domain.University;
 import com.example.umcmatchingcenter.domain.enums.MemberPart;
 import com.example.umcmatchingcenter.domain.enums.MemberRole;
 import com.example.umcmatchingcenter.domain.enums.MemberMatchingStatus;
-import com.example.umcmatchingcenter.domain.enums.MemberRole;
 import com.example.umcmatchingcenter.domain.enums.MemberStatus;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -22,7 +20,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberName(String username);
     Member findByUniversityAndRole(University university, MemberRole role);
 
-    Page<Member> findByGenerationAndRoleAndMatchingStatusAndUniversityIn(int nowGeneration, MemberRole memberRole, MemberMatchingStatus memberMatchingStatus, PageRequest of, List<University> universityList);
+    Page<Member> findByGenerationAndRoleAndMatchingStatusAndUniversityInAndMemberStatus(int nowGeneration, MemberRole memberRole, MemberMatchingStatus memberMatchingStatus, PageRequest of, List<University> universityList, MemberStatus memberStatus);
 
     Page<Member> findAllByMemberStatus(MemberStatus memberStatus, PageRequest pageRequest);
 
@@ -30,7 +28,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findByUniversityInAndMatchingStatusInAndPartAndMemberStatus(List<University> universities, List<MemberMatchingStatus> matchingStatuses, MemberPart part, MemberStatus memberStatus);
 
-    Page<Member> findByGenerationAndRoleAndUniversityIn(int nowGeneration, MemberRole memberRole, PageRequest of, List<University> universityList);
+    Page<Member> findByGenerationAndRoleAndUniversityInAndMemberStatus(int nowGeneration, MemberRole memberRole, PageRequest of, List<University> universityList, MemberStatus memberStatus);
 
 
 }

--- a/src/main/java/com/example/umcmatchingcenter/repository/MemberRepository.java
+++ b/src/main/java/com/example/umcmatchingcenter/repository/MemberRepository.java
@@ -17,7 +17,8 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByMemberName(String username);
+    Optional<Member> findByMemberNameAndMemberStatus(String username, MemberStatus memberStatus);
+
     Member findByUniversityAndRole(University university, MemberRole role);
 
     Page<Member> findByGenerationAndRoleAndMatchingStatusAndUniversityInAndMemberStatus(int nowGeneration, MemberRole memberRole, MemberMatchingStatus memberMatchingStatus, PageRequest of, List<University> universityList, MemberStatus memberStatus);

--- a/src/main/java/com/example/umcmatchingcenter/service/AdminService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/AdminService.java
@@ -56,11 +56,11 @@ public class AdminService {
         Page<Member> members;
         if (memberMatchingStatus != null) {
             // 특정 MemberMatchingStatus가 주어진 경우 해당 조건으로 회원 조회
-            members = memberRepository.findByGenerationAndRoleAndMatchingStatusAndUniversityIn(
-                    NOW_GENERATION, ROLE_CHALLENGER, memberMatchingStatus, PageRequest.of(page, PAGING_SIZE), universityList);
+            members = memberRepository.findByGenerationAndRoleAndMatchingStatusAndUniversityInAndMemberStatus(
+                    NOW_GENERATION, ROLE_CHALLENGER, memberMatchingStatus, PageRequest.of(page, PAGING_SIZE), universityList, MemberStatus.ACTIVE);
         } else {
             // MemberMatchingStatus가 주어지지 않은 경우 모든 회원 조회
-            members = memberRepository.findByGenerationAndRoleAndUniversityIn(NOW_GENERATION, ROLE_CHALLENGER, PageRequest.of(page, PAGING_SIZE),universityList);
+            members = memberRepository.findByGenerationAndRoleAndUniversityInAndMemberStatus(NOW_GENERATION, ROLE_CHALLENGER, PageRequest.of(page, PAGING_SIZE),universityList, MemberStatus.ACTIVE);
         }
 
         return members.stream()

--- a/src/main/java/com/example/umcmatchingcenter/service/AlarmService/AlarmQueryService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/AlarmService/AlarmQueryService.java
@@ -5,6 +5,7 @@ import com.example.umcmatchingcenter.apiPayload.exception.handler.AlarmHandler;
 import com.example.umcmatchingcenter.converter.AlarmConverter;
 import com.example.umcmatchingcenter.domain.Alarm;
 import com.example.umcmatchingcenter.domain.Member;
+import com.example.umcmatchingcenter.domain.enums.MemberStatus;
 import com.example.umcmatchingcenter.dto.AlarmDTO.AlarmResponseDTO;
 import com.example.umcmatchingcenter.repository.AlarmRepository;
 import com.example.umcmatchingcenter.repository.MemberRepository;
@@ -25,7 +26,7 @@ public class AlarmQueryService {
 
     public AlarmResponseDTO.AlarmViewListDTO getAlarmList(String memberName) {
 
-        Member member = memberRepository.findByMemberName(memberName)
+        Member member = memberRepository.findByMemberNameAndMemberStatus(memberName, MemberStatus.ACTIVE)
                 .orElseThrow(()-> new AlarmHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         List<Alarm> alarmList = alarmRepository.findAllByMember(member);

--- a/src/main/java/com/example/umcmatchingcenter/service/memberService/CustomUserDetailsService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/memberService/CustomUserDetailsService.java
@@ -26,7 +26,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     @Transactional
     public UserDetails loadUserByUsername(final String username) {
-        return memberRepository.findByMemberName(username)
+        return memberRepository.findByMemberNameAndMemberStatus(username, MemberStatus.ACTIVE)
                 .map(member -> createUser(username,member))
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }

--- a/src/main/java/com/example/umcmatchingcenter/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/memberService/MemberCommandService.java
@@ -10,6 +10,7 @@ import com.example.umcmatchingcenter.domain.University;
 import com.example.umcmatchingcenter.domain.enums.AlarmType;
 import com.example.umcmatchingcenter.domain.enums.MemberPart;
 import com.example.umcmatchingcenter.domain.enums.MemberRole;
+import com.example.umcmatchingcenter.domain.enums.MemberStatus;
 import com.example.umcmatchingcenter.dto.MemberDTO.LoginRequestDTO;
 import com.example.umcmatchingcenter.dto.MemberDTO.LoginResponseDTO;
 import com.example.umcmatchingcenter.dto.MemberDTO.MemberRequestDTO;
@@ -114,7 +115,7 @@ public class MemberCommandService {
     }
 
     public ApiResponse duplicationMemberName(String memberName){
-        if(memberRepository.findByMemberName(memberName).isPresent()){
+        if(memberRepository.findByMemberNameAndMemberStatus(memberName, MemberStatus.ACTIVE).isPresent()){
             throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXIST);
         }
 

--- a/src/main/java/com/example/umcmatchingcenter/service/memberService/MemberQueryService.java
+++ b/src/main/java/com/example/umcmatchingcenter/service/memberService/MemberQueryService.java
@@ -23,10 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.umcmatchingcenter.service.ProjectVolunteerQueryService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,11 +43,8 @@ public class MemberQueryService {
     }
 
     public Member findMemberByName(String name){
-        Optional<Member> member = memberRepository.findByMemberName(name);
-        if (member.isEmpty()){
-            throw new MemberHandler(MEMBER_NOT_FOUND);
-        }
-        return member.get();
+        return memberRepository.findByMemberNameAndMemberStatus(name, MemberStatus.ACTIVE)
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND) );
     }
 
     public MyInfoDTO getMyInfo(String name) {
@@ -68,7 +62,7 @@ public class MemberQueryService {
 
     public Member getCurrentLoginMember() {
         String memberName = SecurityUtil.getCurrentMember();
-        Optional<Member> foundMember = memberRepository.findByMemberName(memberName);
+        Optional<Member> foundMember = memberRepository.findByMemberNameAndMemberStatus(memberName, MemberStatus.ACTIVE);
         if (foundMember.isPresent() && foundMember != null) {
             return foundMember.get();
         }


### PR DESCRIPTION
## 개요
Resolves: #139 
- 관련 이슈: 지부내 챌린저만 관리되도록 수정
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 맴버 이름으로 조회하는 JPA에 대해 ACTIVE 상태 챌린저만 조회
- 챌린저 관리를 위한 조회시 탈퇴 회원 제외

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CI/CD
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/UMC-Matching-Center/U.M.C_Server?tab=readme-ov-file#-commit-message-convension)  (Ctrl + 클릭하세요.) 
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
